### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -57,12 +57,28 @@
       {
         "url": "https://app.smartsheet.com/b/.*",
         "methods": ["GET", "POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          }
+        }
       },
       {
         "url": "https://api.smartsheet.com/2.0/.*",
         "methods": ["GET", "POST", "PUT", "DELETE"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request updates the API configuration in the `manifest.json` file to support dynamic injection of authentication settings for Smartsheet endpoints. The main improvement is the addition of a `settingsInjection` block, which enables the system to automatically include `client_id` and `client_secret` values in the request body for relevant API calls.

Authentication and configuration enhancements:

* Added a `settingsInjection` section to both Smartsheet endpoint definitions in `manifest.json`, allowing `client_id` and `client_secret` to be injected into the request body for improved authentication handling.